### PR TITLE
Extend readme and add note about show()

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,11 @@
-SimpleNeoPixelDemo
-==================
+# SimpleNeoPixelDemo
 
-A demonstration showing how easy it can be to drive WS2812 NeoPixels
+A demonstration showing how easy it can be to drive WS2812 NeoPixels.
+
+The code sends bits and bytes directly to the LED strip without allocating memory for them,
+which allows to **control hundreds of pixels** with e.g. a small ATtiny85.
+The [Adafruit NeoPixel](https://github.com/adafruit/Adafruit_NeoPixel) library allocates 4 bytes
+per LED, and an ATtiny85 can only control a bit more than 50 pixels.
 
 More info at:
-http://wp.josh.com/2014/05/13/ws2812-neopixels-are-not-so-finicky-once-you-get-to-know-them/
+[NeoPixels Revealed: How to (not need to) generate precisely timed signals](http://wp.josh.com/2014/05/13/ws2812-neopixels-are-not-so-finicky-once-you-get-to-know-them/)

--- a/SimpleNeopixelDemo/SimpleNeopixelDemo.ino
+++ b/SimpleNeopixelDemo/SimpleNeopixelDemo.ino
@@ -35,6 +35,8 @@
 #define T0H  400    // Width of a 0 bit in ns
 #define T0L  900    // Width of a 0 bit in ns
 
+// The reset gap can be 6000 ns, but depending on the LED strip it may have to be increased
+// to values like 600000 ns. If it is too small, the pixels will show nothing most of the time.
 #define RES 6000    // Width of the low gap between bits to cause a frame to latch
 
 // Here are some convience defines for using nanoseconds specs to generate actual CPU delays


### PR DESCRIPTION
The reset gap needs to be larger for some WS2812b LED strips.
Added a hint in the code and extended the README a bit.